### PR TITLE
The sort of the files in a directory must be deterministic

### DIFF
--- a/src/AnnotationService.php
+++ b/src/AnnotationService.php
@@ -136,7 +136,9 @@ class AnnotationService
             }
             closedir($handle);
         }
-
+        usort($files, function ($a, $b) {
+            return (string) $a > (string) $b ? 1 : -1;
+        });
         return $files;
     }
 


### PR DESCRIPTION
When we get the files in a directory, the sort seems to be linked to the OS. (under Mac and Linux we had a issue when the retrieved files are not correct ; because the route are not loaded in the correct order). Under Symfony there were a previous issue [#3683](https://github.com/symfony/symfony/issues/3683)