### PR TITLE
Issue #22

### DIFF
--- a/src/AnnotationService.php
+++ b/src/AnnotationService.php
@@ -80,13 +80,15 @@ class AnnotationService
      */
     public function discoverControllers($dir)
     {
-        if ($this->useCache && $this->cache->contains(self::CONTROLLER_CACHE_INDEX)) {
-            $controllerFiles = $this->cache->fetch('annot.controllerFiles');
+        $cacheKey = self::CONTROLLER_CACHE_INDEX . ".$dir";
+
+        if ($this->useCache && $this->cache->contains($cacheKey)) {
+            $controllerFiles = $this->cache->fetch($cacheKey);
         } else {
             $controllerFiles = $this->app['annot.controllerFinder']($this->app, $dir);
 
             if ($this->useCache) {
-                $this->cache->save(self::CONTROLLER_CACHE_INDEX, $controllerFiles);
+                $this->cache->save($cacheKey, $controllerFiles);
             }
         }
 

--- a/src/AnnotationServiceProvider.php
+++ b/src/AnnotationServiceProvider.php
@@ -38,7 +38,7 @@ class AnnotationServiceProvider implements ServiceProviderInterface, BootablePro
         // Process annotations for all controllers in given directory/directories
         if ($app->offsetExists('annot.controllerDir') && !empty($app['annot.controllerDir'])) {
             
-            $controllerDir = $app['annot.controllerDir'];            
+            $controllerDir = $app['annot.controllerDir'];
             if (!is_array($controllerDir)) {
                 $controllerDir = array($controllerDir);
             }

--- a/test/AnnotationDirArrayTestBase.php
+++ b/test/AnnotationDirArrayTestBase.php
@@ -60,7 +60,7 @@ class AnnotationDirArrayTestBase extends \PHPUnit_Framework_TestCase
             $options['annot.controllerDir'] = self::$CONTROLLER_DIR;
         }
 
-        $this->app->register(new AnnotationServiceProvider(), $options);        
+        $this->app->register(new AnnotationServiceProvider(), $options);
         return $this->app['annot'];
     }
 

--- a/test/AnnotationServiceProviderTest.php
+++ b/test/AnnotationServiceProviderTest.php
@@ -67,15 +67,16 @@ class AnnotationServiceProviderTest extends AnnotationTestBase
 
     public function testControllerCache()
     {
+        $cacheKey = AnnotationService::CONTROLLER_CACHE_INDEX . "." . self::$CONTROLLER_DIR;
         $cache = new TestArrayCache();
         $this->app['annot.cache'] = $cache;
         $this->app['debug'] = false;
         $service = $this->registerAnnotations();
         $service->discoverControllers(self::$CONTROLLER_DIR);
-        $this->assertCount(13, $cache->fetch(AnnotationService::CONTROLLER_CACHE_INDEX));
+        $this->assertCount(13, $cache->fetch($cacheKey));
 
         $files = $service->discoverControllers(self::$CONTROLLER_DIR);
-        $this->assertTrue($cache->wasFetched(AnnotationService::CONTROLLER_CACHE_INDEX));
+        $this->assertTrue($cache->wasFetched($cacheKey));
         $this->assertContains(self::CONTROLLER_NAMESPACE."SubDir\\SubDirTestController", $files);
         $this->assertContains(self::CONTROLLER_NAMESPACE."TestController", $files);
         $this->assertCount(13, $files);
@@ -95,6 +96,11 @@ class TestArrayCache extends ArrayCache
     {
         $this->fetchedIDs[$id] = true;
         return parent::fetch($id);
+    }
+
+    public function clearWasFetched()
+    {
+        $this->fetchedIDs = [];
     }
 }
 


### PR DESCRIPTION
Fixed caching with multiple controllerDir directories.  Issue #22 
Each controllerDir is cached separately, but they were using the same cache key, so one was overwritten.  The cache key is now unique for each controllerDir.